### PR TITLE
link to docs and tests run instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Conjugate Models
-![Tests](https://github.com/wd60622/conjugate/actions/workflows/tests.yml/badge.svg) [![PyPI version](https://badge.fury.io/py/conjugate-models.svg)](https://badge.fury.io/py/conjugate-models) [![docs](https://github.com/wd60622/conjugate/actions/workflows/docs.yml/badge.svg)](https://github.com/wd60622/conjugate/actions/workflows/docs.yml)
+[![Tests](https://github.com/wd60622/conjugate/actions/workflows/tests.yml/badge.svg)](https://github.com/wd60622/conjugate/actions/workflows/tests.yml) [![PyPI version](https://badge.fury.io/py/conjugate-models.svg)](https://badge.fury.io/py/conjugate-models) [![docs](https://github.com/wd60622/conjugate/actions/workflows/docs.yml/badge.svg)](https://wd60622.github.io/conjugate/)
 
 Bayesian conjugate models in Python
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ hide:
     - navigation 
 ---
 # Conjugate Models
-![Tests](https://github.com/wd60622/conjugate/actions/workflows/tests.yml/badge.svg) [![PyPI version](https://badge.fury.io/py/conjugate-models.svg)](https://badge.fury.io/py/conjugate-models) [![docs](https://github.com/wd60622/conjugate/actions/workflows/docs.yml/badge.svg)](https://github.com/wd60622/conjugate/actions/workflows/docs.yml)
+[![Tests](https://github.com/wd60622/conjugate/actions/workflows/tests.yml/badge.svg)](https://github.com/wd60622/conjugate/actions/workflows/tests.yml) [![PyPI version](https://badge.fury.io/py/conjugate-models.svg)](https://badge.fury.io/py/conjugate-models) [![docs](https://github.com/wd60622/conjugate/actions/workflows/docs.yml/badge.svg)](https://wd60622.github.io/conjugate/)
 
 Bayesian conjugate models in Python
 


### PR DESCRIPTION
link to the docs directly as well as the test workflow