### PR TITLE
Standardize `prior` as parameter name

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ N = 10
 prior = Beta(1, 1)
 prior_predictive: BetaBinomial = binomial_beta_predictive(n=N, beta=prior)
 
-posterior: Beta = binomial_beta(n=N, x=X, beta_prior=prior)
+posterior: Beta = binomial_beta(n=N, x=X, prior=prior)
 posterior_predictive: BetaBinomial = binomial_beta_predictive(n=N, beta=posterior) 
 ```
 

--- a/conjugate/distributions.py
+++ b/conjugate/distributions.py
@@ -909,6 +909,9 @@ class VonMisesKnownDirectionProportional:
     r: NUMERIC
     """
 
+    c: NUMERIC
+    r: NUMERIC
+
     def approx_log_likelihood(self, kappa: NUMERIC, ln=np.log, i0=i0) -> NUMERIC:
         """Approximate log likelihood.
 

--- a/conjugate/models.py
+++ b/conjugate/models.py
@@ -72,13 +72,13 @@ def get_binomial_beta_posterior_params(
     return alpha_post, beta_post
 
 
-def binomial_beta(n: NUMERIC, x: NUMERIC, beta_prior: Beta) -> Beta:
+def binomial_beta(n: NUMERIC, x: NUMERIC, prior: Beta) -> Beta:
     """Posterior distribution for a binomial likelihood with a beta prior.
 
     Args:
         n: total number of trials
         x: successes from that trials
-        beta_prior: Beta distribution prior
+        prior: Beta distribution prior
 
     Returns:
         Beta distribution posterior
@@ -102,7 +102,7 @@ def binomial_beta(n: NUMERIC, x: NUMERIC, beta_prior: Beta) -> Beta:
         posterior = binomial_beta(
             n=impressions,
             x=clicks,
-            beta_prior=prior
+            prior=prior
         )
 
         ax = plt.subplot(111)
@@ -114,7 +114,7 @@ def binomial_beta(n: NUMERIC, x: NUMERIC, beta_prior: Beta) -> Beta:
 
     """
     alpha_post, beta_post = get_binomial_beta_posterior_params(
-        beta_prior.alpha, beta_prior.beta, n, x
+        prior.alpha, prior.beta, n, x
     )
 
     return Beta(alpha=alpha_post, beta=beta_post)
@@ -168,12 +168,12 @@ def binomial_beta_predictive(n: NUMERIC, beta: Beta) -> BetaBinomial:
     return BetaBinomial(n=n, alpha=beta.alpha, beta=beta.beta)
 
 
-def bernoulli_beta(x: NUMERIC, beta_prior: Beta) -> Beta:
+def bernoulli_beta(x: NUMERIC, prior: Beta) -> Beta:
     """Posterior distribution for a bernoulli likelihood with a beta prior.
 
     Args:
         x: successes from a single trial
-        beta_prior: Beta distribution prior
+        prior: Beta distribution prior
 
     Returns:
         Beta distribution posterior
@@ -191,7 +191,7 @@ def bernoulli_beta(x: NUMERIC, beta_prior: Beta) -> Beta:
         x = 1
         posterior = bernoulli_beta(
             x=x,
-            beta_prior=prior
+            prior=prior
         )
 
         posterior.dist.ppf([0.025, 0.975])
@@ -199,7 +199,7 @@ def bernoulli_beta(x: NUMERIC, beta_prior: Beta) -> Beta:
         ```
 
     """
-    return binomial_beta(n=1, x=x, beta_prior=beta_prior)
+    return binomial_beta(n=1, x=x, prior=prior)
 
 
 def bernoulli_beta_predictive(beta: Beta) -> BetaBinomial:
@@ -217,9 +217,7 @@ def bernoulli_beta_predictive(beta: Beta) -> BetaBinomial:
     return binomial_beta_predictive(n=1, beta=beta)
 
 
-def negative_binomial_beta(
-    r: NUMERIC, n: NUMERIC, x: NUMERIC, beta_prior: Beta
-) -> Beta:
+def negative_binomial_beta(r: NUMERIC, n: NUMERIC, x: NUMERIC, prior: Beta) -> Beta:
     """Posterior distribution for a negative binomial likelihood with a beta prior.
 
     Assumed known number of failures r
@@ -228,14 +226,14 @@ def negative_binomial_beta(
         r: number of failures
         n: number of trials
         x: number of successes
-        beta_prior: Beta distribution prior
+        prior: Beta distribution prior
 
     Returns:
         Beta distribution posterior
 
     """
-    alpha_post = beta_prior.alpha + (r * n)
-    beta_post = beta_prior.beta + x
+    alpha_post = prior.alpha + (r * n)
+    beta_post = prior.beta + x
 
     return Beta(alpha=alpha_post, beta=beta_post)
 
@@ -257,7 +255,7 @@ def negative_binomial_beta_predictive(r: NUMERIC, beta: Beta) -> BetaNegativeBin
 
 
 def hypergeometric_beta_binomial(
-    x_total: NUMERIC, n: NUMERIC, beta_binomial_prior: BetaBinomial
+    x_total: NUMERIC, n: NUMERIC, prior: BetaBinomial
 ) -> BetaBinomial:
     """Hypergeometric likelihood with a BetaBinomial prior.
 
@@ -267,27 +265,27 @@ def hypergeometric_beta_binomial(
     Args:
         x_total: sum of all trials outcomes
         n: total number of trials
-        beta_binomial_prior: BetaBinomial prior
+        prior: BetaBinomial prior
             n is the known N / total population size
 
     Returns:
         BetaBinomial posterior distribution
 
     """
-    n = beta_binomial_prior.n
-    alpha_post = beta_binomial_prior.alpha + x_total
-    beta_post = beta_binomial_prior.beta + (n - x_total)
+    n = prior.n
+    alpha_post = prior.alpha + x_total
+    beta_post = prior.beta + (n - x_total)
 
     return BetaBinomial(n=n, alpha=alpha_post, beta=beta_post)
 
 
-def geometric_beta(x_total, n, beta_prior: Beta, one_start: bool = True) -> Beta:
+def geometric_beta(x_total, n, prior: Beta, one_start: bool = True) -> Beta:
     """Posterior distribution for a geometric likelihood with a beta prior.
 
     Args:
         x_total: sum of all trials outcomes
         n: total number of trials
-        beta_prior: Beta distribution prior
+        prior: Beta distribution prior
         one_start: whether to outcomes start at 1, defaults to True. False is 0 start.
 
     Returns:
@@ -310,7 +308,7 @@ def geometric_beta(x_total, n, beta_prior: Beta, one_start: bool = True) -> Beta
         posterior = geometric_beta(
             x_total=data.sum(),
             n=data.size,
-            beta_prior=prior
+            prior=prior
         )
 
         ax = plt.subplot(111)
@@ -322,8 +320,8 @@ def geometric_beta(x_total, n, beta_prior: Beta, one_start: bool = True) -> Beta
         ```
 
     """
-    alpha_post = beta_prior.alpha + n
-    beta_post = beta_prior.beta + x_total
+    alpha_post = prior.alpha + n
+    beta_post = prior.beta + x_total
 
     if one_start:
         beta_post = beta_post - n
@@ -344,18 +342,18 @@ def get_categorical_dirichlet_posterior_params(
     return get_dirichlet_posterior_params(alpha_prior, x)
 
 
-def categorical_dirichlet(x: NUMERIC, dirichlet_prior: Dirichlet) -> Dirichlet:
+def categorical_dirichlet(x: NUMERIC, prior: Dirichlet) -> Dirichlet:
     """Posterior distribution of Categorical model with Dirichlet prior.
 
     Args:
         x: counts
-        dirichlet_prior: Dirichlet prior on the counts
+        prior: Dirichlet prior on the counts
 
     Returns:
         Dirichlet posterior distribution
 
     """
-    alpha_post = get_dirichlet_posterior_params(dirichlet_prior.alpha, x)
+    alpha_post = get_dirichlet_posterior_params(prior.alpha, x)
 
     return Dirichlet(alpha=alpha_post)
 
@@ -383,12 +381,12 @@ def get_multi_categorical_dirichlet_posterior_params(
     return get_dirichlet_posterior_params(alpha_prior, x)
 
 
-def multinomial_dirichlet(x: NUMERIC, dirichlet_prior: Dirichlet) -> Dirichlet:
+def multinomial_dirichlet(x: NUMERIC, prior: Dirichlet) -> Dirichlet:
     """Posterior distribution of Multinomial model with Dirichlet prior.
 
     Args:
         x: counts
-        dirichlet_prior: Dirichlet prior on the counts
+        prior: Dirichlet prior on the counts
 
     Returns:
         Dirichlet posterior distribution
@@ -414,7 +412,7 @@ def multinomial_dirichlet(x: NUMERIC, dirichlet_prior: Dirichlet) -> Dirichlet:
         prior = Dirichlet([1, 1, 1])
         posterior = multinomial_dirichlet(
             x=data.sum(axis=0),
-            dirichlet_prior=prior
+            prior=prior
         )
 
         ax = plt.subplot(111)
@@ -425,7 +423,7 @@ def multinomial_dirichlet(x: NUMERIC, dirichlet_prior: Dirichlet) -> Dirichlet:
         ```
 
     """
-    alpha_post = get_dirichlet_posterior_params(dirichlet_prior.alpha, x)
+    alpha_post = get_dirichlet_posterior_params(prior.alpha, x)
 
     return Dirichlet(alpha=alpha_post)
 
@@ -456,20 +454,20 @@ def get_poisson_gamma_posterior_params(
     return alpha_post, beta_post
 
 
-def poisson_gamma(x_total: NUMERIC, n: NUMERIC, gamma_prior: Gamma) -> Gamma:
+def poisson_gamma(x_total: NUMERIC, n: NUMERIC, prior: Gamma) -> Gamma:
     """Posterior distribution for a poisson likelihood with a gamma prior.
 
     Args:
         x_total: sum of all outcomes
         n: total number of samples in x_total
-        gamma_prior: Gamma prior
+        prior: Gamma prior
 
     Returns:
         Gamma posterior distribution
 
     """
     alpha_post, beta_post = get_poisson_gamma_posterior_params(
-        alpha=gamma_prior.alpha, beta=gamma_prior.beta, x_total=x_total, n=n
+        alpha=prior.alpha, beta=prior.beta, x_total=x_total, n=n
     )
 
     return Gamma(alpha=alpha_post, beta=beta_post)
@@ -497,20 +495,20 @@ def poisson_gamma_predictive(gamma: Gamma, n: NUMERIC = 1) -> NegativeBinomial:
 get_exponential_gamma_posterior_params = get_poisson_gamma_posterior_params
 
 
-def exponential_gamma(x_total: NUMERIC, n: NUMERIC, gamma_prior: Gamma) -> Gamma:
+def exponential_gamma(x_total: NUMERIC, n: NUMERIC, prior: Gamma) -> Gamma:
     """Posterior distribution for an exponential likelihood with a gamma prior.
 
     Args:
         x_total: sum of all outcomes
         n: total number of samples in x_total
-        gamma_prior: Gamma prior
+        prior: Gamma prior
 
     Returns:
         Gamma posterior distribution
 
     """
     alpha_post, beta_post = get_exponential_gamma_posterior_params(
-        alpha=gamma_prior.alpha, beta=gamma_prior.beta, x_total=x_total, n=n
+        alpha=prior.alpha, beta=prior.beta, x_total=x_total, n=n
     )
 
     return Gamma(alpha=alpha_post, beta=beta_post)
@@ -546,7 +544,7 @@ def exponential_gamma_predictive(gamma: Gamma) -> Lomax:
         posterior = exponential_gamma(
             n=n_samples,
             x_total=data.sum(),
-            gamma_prior=prior
+            prior=prior
         )
 
         prior_predictive = expotential_gamma_predictive(prior)
@@ -564,7 +562,7 @@ def exponential_gamma_predictive(gamma: Gamma) -> Lomax:
 
 
 def gamma_known_shape(
-    x_total: NUMERIC, n: NUMERIC, alpha: NUMERIC, gamma_prior: Gamma
+    x_total: NUMERIC, n: NUMERIC, alpha: NUMERIC, prior: Gamma
 ) -> Gamma:
     """Gamma likelihood with a gamma prior.
 
@@ -574,7 +572,7 @@ def gamma_known_shape(
         x_total: sum of all outcomes
         n: total number of samples in x_total
         alpha: known shape parameter
-        gamma_prior: Gamma prior
+        prior: Gamma prior
 
     Returns:
         Gamma posterior distribution
@@ -603,7 +601,7 @@ def gamma_known_shape(
             n=n_samples,
             x_total=data.sum(),
             alpha=known_shape,
-            gamma_prior=prior
+            prior=prior
         )
 
         bound = 10
@@ -616,8 +614,8 @@ def gamma_known_shape(
         ```
 
     """
-    alpha_post = gamma_prior.alpha + n * alpha
-    beta_post = gamma_prior.beta + x_total
+    alpha_post = prior.alpha + n * alpha
+    beta_post = prior.beta + x_total
 
     return Gamma(alpha=alpha_post, beta=beta_post)
 
@@ -640,7 +638,7 @@ def normal_known_variance(
     x_total: NUMERIC,
     n: NUMERIC,
     var: NUMERIC,
-    normal_prior: Normal,
+    prior: Normal,
 ) -> Normal:
     """Posterior distribution for a normal likelihood with known variance and a normal prior on mean.
 
@@ -648,7 +646,7 @@ def normal_known_variance(
         x_total: sum of all outcomes
         n: total number of samples in x_total
         var: known variance
-        normal_prior: Normal prior for mean
+        prior: Normal prior for mean
 
     Returns:
         Normal posterior distribution for the mean
@@ -677,7 +675,7 @@ def normal_known_variance(
             n=n_samples,
             x_total=data.sum(),
             var=known_var,
-            normal_prior=prior
+            prior=prior
         )
 
         bound = 5
@@ -690,11 +688,11 @@ def normal_known_variance(
         ```
 
     """
-    mu_post = ((normal_prior.mu / normal_prior.sigma**2) + (x_total / var)) / (
-        (1 / normal_prior.sigma**2) + (n / var)
+    mu_post = ((prior.mu / prior.sigma**2) + (x_total / var)) / (
+        (1 / prior.sigma**2) + (n / var)
     )
 
-    var_post = 1 / ((1 / normal_prior.sigma**2) + (n / var))
+    var_post = 1 / ((1 / prior.sigma**2) + (n / var))
 
     return Normal(mu=mu_post, sigma=var_post**0.5)
 
@@ -733,7 +731,7 @@ def normal_known_variance_predictive(var: NUMERIC, normal: Normal) -> Normal:
             n=n_samples,
             x_total=data.sum(),
             var=known_var,
-            normal_prior=prior
+            prior=prior
         )
 
         prior_predictive = normal_known_variance_predictive(
@@ -763,7 +761,7 @@ def normal_known_precision(
     x_total: NUMERIC,
     n: NUMERIC,
     precision: NUMERIC,
-    normal_prior: Normal,
+    prior: Normal,
 ) -> Normal:
     """Posterior distribution for a normal likelihood with known precision and a normal prior on mean.
 
@@ -771,7 +769,7 @@ def normal_known_precision(
         x_total: sum of all outcomes
         n: total number of samples in x_total
         precision: known precision
-        normal_prior: Normal prior for mean
+        prior: Normal prior for mean
 
     Returns:
         Normal posterior distribution for the mean
@@ -800,7 +798,7 @@ def normal_known_precision(
             n=n_samples,
             x_total=data.sum(),
             precision=known_precision,
-            normal_prior=prior
+            prior=prior
         )
 
         bound = 5
@@ -817,7 +815,7 @@ def normal_known_precision(
         x_total=x_total,
         n=n,
         var=1 / precision,
-        normal_prior=normal_prior,
+        prior=prior,
     )
 
 
@@ -855,7 +853,7 @@ def normal_known_precision_predictive(precision: NUMERIC, normal: Normal) -> Nor
             n=n_samples,
             x_total=data.sum(),
             precision=known_precision,
-            normal_prior=prior
+            prior=prior
         )
 
         prior_predictive = normal_known_precision_predictive(
@@ -888,7 +886,7 @@ def normal_known_mean(
     x2_total: NUMERIC,
     n: NUMERIC,
     mu: NUMERIC,
-    inverse_gamma_prior: InverseGamma,
+    prior: InverseGamma,
 ) -> InverseGamma:
     """Posterior distribution for a normal likelihood with a known mean and a variance prior.
 
@@ -897,16 +895,14 @@ def normal_known_mean(
         x2_total: sum of all outcomes squared
         n: total number of samples in x_total
         mu: known mean
-        inverse_gamma_prior: InverseGamma prior for variance
+        prior: InverseGamma prior for variance
 
     Returns:
         InverseGamma posterior distribution for the variance
 
     """
-    alpha_post = inverse_gamma_prior.alpha + (n / 2)
-    beta_post = inverse_gamma_prior.beta + (
-        0.5 * (x2_total - (2 * mu * x_total) + (n * (mu**2)))
-    )
+    alpha_post = prior.alpha + (n / 2)
+    beta_post = prior.beta + (0.5 * (x2_total - (2 * mu * x_total) + (n * (mu**2))))
 
     return InverseGamma(alpha=alpha_post, beta=beta_post)
 
@@ -946,7 +942,7 @@ def normal_known_mean_predictive(mu: NUMERIC, inverse_gamma: InverseGamma) -> St
             x_total=data.sum(),
             x2_total=(data**2).sum(),
             mu=known_mu,
-            inverse_gamma_prior=prior
+            prior=prior
         )
 
         bound = 5
@@ -978,7 +974,7 @@ def normal_normal_inverse_gamma(
     x_total: NUMERIC,
     x2_total: NUMERIC,
     n: NUMERIC,
-    normal_inverse_gamma_prior: NormalInverseGamma,
+    prior: NormalInverseGamma,
 ) -> NormalInverseGamma:
     """Posterior distribution for a normal likelihood with a normal inverse gamma prior.
 
@@ -988,7 +984,7 @@ def normal_normal_inverse_gamma(
         x_total: sum of all outcomes
         x2_total: sum of all outcomes squared
         n: total number of samples in x_total and x2_total
-        normal_inverse_gamma_prior: NormalInverseGamma prior
+        prior: NormalInverseGamma prior
 
     Returns:
         NormalInverseGamma posterior distribution
@@ -996,16 +992,14 @@ def normal_normal_inverse_gamma(
     """
     x_mean = x_total / n
 
-    nu_0_inv = normal_inverse_gamma_prior.nu
+    nu_0_inv = prior.nu
 
     nu_post_inv = nu_0_inv + n
-    mu_post = ((nu_0_inv * normal_inverse_gamma_prior.mu) + (n * x_mean)) / nu_post_inv
+    mu_post = ((nu_0_inv * prior.mu) + (n * x_mean)) / nu_post_inv
 
-    alpha_post = normal_inverse_gamma_prior.alpha + (n / 2)
-    beta_post = normal_inverse_gamma_prior.beta + 0.5 * (
-        (normal_inverse_gamma_prior.mu**2) * nu_0_inv
-        + x2_total
-        - (mu_post**2) * nu_post_inv
+    alpha_post = prior.alpha + (n / 2)
+    beta_post = prior.beta + 0.5 * (
+        (prior.mu**2) * nu_0_inv + x2_total - (mu_post**2) * nu_post_inv
     )
 
     return NormalInverseGamma(
@@ -1043,7 +1037,7 @@ def normal_normal_inverse_gamma_predictive(
 def linear_regression(
     X: NUMERIC,
     y: NUMERIC,
-    normal_inverse_gamma_prior: NormalInverseGamma,
+    prior: NormalInverseGamma,
     inv=np.linalg.inv,
 ) -> NormalInverseGamma:
     """Posterior distribution for a linear regression model with a normal inverse gamma prior.
@@ -1053,7 +1047,7 @@ def linear_regression(
     Args:
         X: design matrix
         y: response vector
-        normal_inverse_gamma_prior: NormalInverseGamma prior
+        prior: NormalInverseGamma prior
         inv: function to invert matrix, defaults to np.linalg.inv
 
     Returns:
@@ -1062,7 +1056,7 @@ def linear_regression(
     """
     N = X.shape[0]
 
-    delta = inv(normal_inverse_gamma_prior.delta_inverse)
+    delta = inv(prior.delta_inverse)
 
     delta_post = (X.T @ X) + delta
     delta_post_inverse = inv(delta_post)
@@ -1072,16 +1066,16 @@ def linear_regression(
         delta_post_inverse
         # (B, 1)
         # (B, B) * (B, 1) +  (B, N) * (N, 1)
-        @ (delta @ normal_inverse_gamma_prior.mu + X.T @ y)
+        @ (delta @ prior.mu + X.T @ y)
     )
 
-    alpha_post = normal_inverse_gamma_prior.alpha + (0.5 * N)
-    beta_post = normal_inverse_gamma_prior.beta + (
+    alpha_post = prior.alpha + (0.5 * N)
+    beta_post = prior.beta + (
         0.5
         * (
             (y.T @ y)
             # (1, B) * (B, B) * (B, 1)
-            + (normal_inverse_gamma_prior.mu.T @ delta @ normal_inverse_gamma_prior.mu)
+            + (prior.mu.T @ delta @ prior.mu)
             # (1, B) * (B, B) * (B, 1)
             - (mu_post.T @ delta_post @ mu_post)
         )
@@ -1120,14 +1114,14 @@ def linear_regression_predictive(
 
 
 def uniform_pareto(
-    x_max: NUMERIC, n: NUMERIC, pareto_prior: Pareto, max_fn=np.maximum
+    x_max: NUMERIC, n: NUMERIC, prior: Pareto, max_fn=np.maximum
 ) -> Pareto:
     """Posterior distribution for a uniform likelihood with a pareto prior.
 
     Args:
         x_max: maximum value
         n: number of samples
-        pareto_prior: Pareto prior
+        prior: Pareto prior
         max_fn: elementwise max function, defaults to np.maximum
 
     Returns:
@@ -1151,19 +1145,19 @@ def uniform_pareto(
         posterior = uniform_pareto(
             x_max=data.max(),
             n=n_samples,
-            pareto_prior=prior
+            prior=prior
         )
         ```
 
     """
-    alpha_post = pareto_prior.alpha + n
-    x_m_post = max_fn(pareto_prior.x_m, x_max)
+    alpha_post = prior.alpha + n
+    x_m_post = max_fn(prior.x_m, x_max)
 
     return Pareto(x_m=x_m_post, alpha=alpha_post)
 
 
 def pareto_gamma(
-    n: NUMERIC, ln_x_total: NUMERIC, x_m: NUMERIC, gamma_prior: Gamma, ln=np.log
+    n: NUMERIC, ln_x_total: NUMERIC, x_m: NUMERIC, prior: Gamma, ln=np.log
 ) -> Gamma:
     """Posterior distribution for a pareto likelihood with a gamma prior.
 
@@ -1173,7 +1167,7 @@ def pareto_gamma(
         n: number of samples
         ln_x_total: sum of the log of all outcomes
         x_m: The known minimum value
-        gamma_prior: Gamma prior
+        prior: Gamma prior
         ln: function to take the natural log, defaults to np.log
 
     Returns:
@@ -1202,7 +1196,7 @@ def pareto_gamma(
             n=n_samples,
             ln_x_total=np.log(data).sum(),
             x_m=x_m_known,
-            gamma_prior=prior
+            prior=prior
         )
 
         ax = plt.subplot(111)
@@ -1214,8 +1208,8 @@ def pareto_gamma(
         ```
 
     """
-    alpha_post = gamma_prior.alpha + n
-    beta_post = gamma_prior.beta + ln_x_total - n * ln(x_m)
+    alpha_post = prior.alpha + n
+    beta_post = prior.beta + ln_x_total - n * ln(x_m)
 
     return Gamma(alpha=alpha_post, beta=beta_post)
 
@@ -1224,7 +1218,7 @@ def gamma(
     x_total: NUMERIC,
     x_prod: NUMERIC,
     n: NUMERIC,
-    proportional_prior: GammaProportional,
+    prior: GammaProportional,
 ) -> GammaProportional:
     """Posterior distribution for a gamma likelihood.
 
@@ -1234,16 +1228,16 @@ def gamma(
         x_total: sum of all outcomes
         x_prod: product of all outcomes
         n: total number of samples in x_total and x_prod
-        proportional_prior: GammaProportional prior
+        prior: GammaProportional prior
 
     Returns:
         GammaProportional posterior distribution
 
     """
-    p_post = proportional_prior.p * x_prod
-    q_post = proportional_prior.q + x_total
-    r_post = proportional_prior.r + n
-    s_post = proportional_prior.s + n
+    p_post = prior.p * x_prod
+    q_post = prior.q + x_total
+    r_post = prior.r + n
+    s_post = prior.s + n
 
     return GammaProportional(p=p_post, q=q_post, r=r_post, s=s_post)
 
@@ -1252,7 +1246,7 @@ def gamma_known_rate(
     x_prod: NUMERIC,
     n: NUMERIC,
     beta: NUMERIC,
-    proportional_prior: GammaKnownRateProportional,
+    prior: GammaKnownRateProportional,
 ) -> GammaKnownRateProportional:
     """Posterior distribution for a gamma likelihood.
 
@@ -1267,9 +1261,9 @@ def gamma_known_rate(
         GammaKnownRateProportional posterior distribution
 
     """
-    a_post = proportional_prior.a * x_prod
-    b_post = proportional_prior.b + n
-    c_post = proportional_prior.c + n
+    a_post = prior.a * x_prod
+    b_post = prior.b + n
+    c_post = prior.c + n
 
     return GammaKnownRateProportional(a=a_post, b=b_post, c=c_post)
 
@@ -1278,7 +1272,7 @@ def beta(
     x_prod: NUMERIC,
     one_minus_x_prod: NUMERIC,
     n: NUMERIC,
-    proportional_prior: BetaProportional,
+    prior: BetaProportional,
 ) -> BetaProportional:
     """Posterior distribution for a Beta likelihood.
 
@@ -1288,15 +1282,15 @@ def beta(
         x_prod: product of all outcomes
         one_minus_x_prod: product of all (1 - outcomes)
         n: total number of samples in x_prod and one_minus_x_prod
-        proportional_prior: BetaProportional prior
+        prior: BetaProportional prior
 
     Returns:
         BetaProportional posterior distribution
 
     """
-    p_post = proportional_prior.p * x_prod
-    q_post = proportional_prior.q * one_minus_x_prod
-    k_post = proportional_prior.k + n
+    p_post = prior.p * x_prod
+    q_post = prior.q * one_minus_x_prod
+    k_post = prior.k + n
 
     return BetaProportional(p=p_post, q=q_post, k=k_post)
 
@@ -1306,7 +1300,7 @@ def von_mises_known_concentration(
     sin_total: NUMERIC,
     n: NUMERIC,
     kappa: NUMERIC,
-    von_mises_prior: VonMisesKnownConcentration,
+    prior: VonMisesKnownConcentration,
     sin=np.sin,
     cos=np.cos,
     arctan2=np.arctan2,
@@ -1320,18 +1314,16 @@ def von_mises_known_concentration(
         sin_total: sum of all sines
         n: total number of samples in cos_total and sin_total
         kappa: known concentration parameter
-        von_mises_prior: VonMisesKnownConcentration prior
+        prior: VonMisesKnownConcentration prior
 
     Returns:
         VonMisesKnownConcentration posterior distribution
 
     """
-    sin_total_post = von_mises_prior.a * sin(von_mises_prior.b) + sin_total
+    sin_total_post = prior.a * sin(prior.b) + sin_total
     a_post = kappa * sin_total_post
 
-    b_post = arctan2(
-        sin_total_post, von_mises_prior.a * cos(von_mises_prior.b) + cos_total
-    )
+    b_post = arctan2(sin_total_post, prior.a * cos(prior.b) + cos_total)
 
     return VonMisesKnownConcentration(a=a_post, b=b_post)
 
@@ -1339,7 +1331,7 @@ def von_mises_known_concentration(
 def von_mises_known_direction(
     centered_cos_total: NUMERIC,
     n: NUMERIC,
-    proportional_prior: VonMisesKnownDirectionProportional,
+    prior: VonMisesKnownDirectionProportional,
 ) -> VonMisesKnownDirectionProportional:
     """VonMises likelihood with known direction parameter.
 
@@ -1348,34 +1340,34 @@ def von_mises_known_direction(
     Args:
         centered_cos_total: sum of all centered cosines. sum cos(x - known direction))
         n: total number of samples in centered_cos_total
-        proportional_prior: VonMisesKnownDirectionProportional prior
+        prior: VonMisesKnownDirectionProportional prior
 
     """
 
     return VonMisesKnownDirectionProportional(
-        c=proportional_prior.c + n,
-        r=proportional_prior.r + centered_cos_total,
+        c=prior.c + n,
+        r=prior.r + centered_cos_total,
     )
 
 
 def multivariate_normal_known_mean(
     X: NUMERIC,
     mu: NUMERIC,
-    inverse_wishart_prior: InverseWishart,
+    prior: InverseWishart,
 ) -> InverseWishart:
     """Multivariate normal likelihood with known mean and inverse wishart prior.
 
     Args:
         X: design matrix
         mu: known mean
-        inverse_wishart_prior: InverseWishart prior
+        prior: InverseWishart prior
 
     Returns:
         InverseWishart posterior distribution
 
     """
-    nu_post = inverse_wishart_prior.nu + X.shape[0]
-    psi_post = inverse_wishart_prior.psi + (X - mu).T @ (X - mu)
+    nu_post = prior.nu + X.shape[0]
+    psi_post = prior.psi + (X - mu).T @ (X - mu)
 
     return InverseWishart(
         nu=nu_post,
@@ -1385,7 +1377,7 @@ def multivariate_normal_known_mean(
 
 def multivariate_normal(
     X: NUMERIC,
-    normal_inverse_wishart_prior: NormalInverseWishart,
+    prior: NormalInverseWishart,
     outer=np.outer,
 ) -> NormalInverseWishart:
     """Multivariate normal likelihood with normal inverse wishart prior.
@@ -1393,7 +1385,7 @@ def multivariate_normal(
     Args:
         X: design matrix
         mu: known mean
-        normal_inverse_wishart_prior: NormalInverseWishart prior
+        prior: NormalInverseWishart prior
         outer: function to take outer product, defaults to np.outer
 
     Returns:
@@ -1437,7 +1429,7 @@ def multivariate_normal(
 
         posterior = multivariate_normal(
             X=data,
-            normal_inverse_wishart_prior=prior,
+            prior=prior,
         )
         ```
     """
@@ -1445,22 +1437,16 @@ def multivariate_normal(
     X_mean = X.mean(axis=0)
     C = (X - X_mean).T @ (X - X_mean)
 
-    mu_post = (
-        normal_inverse_wishart_prior.mu * normal_inverse_wishart_prior.kappa
-        + n * X_mean
-    ) / (normal_inverse_wishart_prior.kappa + n)
+    mu_post = (prior.mu * prior.kappa + n * X_mean) / (prior.kappa + n)
 
-    kappa_post = normal_inverse_wishart_prior.kappa + n
-    nu_post = normal_inverse_wishart_prior.nu + n
+    kappa_post = prior.kappa + n
+    nu_post = prior.nu + n
 
-    mean_difference = X_mean - normal_inverse_wishart_prior.mu
+    mean_difference = X_mean - prior.mu
     psi_post = (
-        normal_inverse_wishart_prior.psi
+        prior.psi
         + C
-        + outer(mean_difference, mean_difference)
-        * n
-        * normal_inverse_wishart_prior.kappa
-        / kappa_post
+        + outer(mean_difference, mean_difference) * n * prior.kappa / kappa_post
     )
 
     return NormalInverseWishart(
@@ -1521,7 +1507,7 @@ def multivariate_normal_predictive(
 
         posterior = multivariate_normal(
             X=data,
-            normal_inverse_wishart_prior=prior,
+            prior=prior,
         )
         prior_predictive = multivariate_normal_predictive(prior)
         posterior_predictive = multivariate_normal_predictive(posterior)
@@ -1573,7 +1559,7 @@ def log_normal_normal_inverse_gamma(
     ln_x_total: NUMERIC,
     ln_x2_total: NUMERIC,
     n: NUMERIC,
-    normal_inverse_gamma_prior: NormalInverseGamma,
+    prior: NormalInverseGamma,
 ) -> NormalInverseGamma:
     """Log normal likelihood with a normal inverse gamma prior.
 
@@ -1585,7 +1571,7 @@ def log_normal_normal_inverse_gamma(
         ln_x_total: sum of the log of all outcomes
         ln_x2_total: sum of the log of all outcomes squared
         n: total number of samples in ln_x_total and ln_x2_total
-        normal_inverse_gamma_prior: NormalInverseGamma prior
+        prior: NormalInverseGamma prior
 
     Returns:
         NormalInverseGamma posterior distribution
@@ -1615,7 +1601,7 @@ def log_normal_normal_inverse_gamma(
             ln_x_total=ln_data.sum(),
             ln_x2_total=(ln_data**2).sum(),
             n=n_samples,
-            normal_inverse_gamma_prior=prior
+            prior=prior
         )
 
         fig, axes = plt.subplots(ncols=2)
@@ -1636,7 +1622,7 @@ def log_normal_normal_inverse_gamma(
         x_total=ln_x_total,
         x2_total=ln_x2_total,
         n=n,
-        normal_inverse_gamma_prior=normal_inverse_gamma_prior,
+        prior=prior,
     )
 
 

--- a/conjugate/models.py
+++ b/conjugate/models.py
@@ -31,6 +31,7 @@ Below are the supported models
 """
 
 from typing import Tuple
+from functools import wraps
 
 import numpy as np
 
@@ -63,6 +64,28 @@ from conjugate.distributions import (
 from conjugate._typing import NUMERIC
 
 
+def deprecate_prior_parameter(old_name: str):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            if old_name in kwargs:
+                msg = (
+                    f"Parameter {old_name!r} is deprecated, use 'prior' instead. "
+                    "It will be removed in a future version."
+                )
+                warnings.warn(
+                    msg,
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                kwargs["prior"] = kwargs.pop(old_name)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
 def get_binomial_beta_posterior_params(
     alpha_prior: NUMERIC, beta_prior: NUMERIC, n: NUMERIC, x: NUMERIC
 ) -> Tuple[NUMERIC, NUMERIC]:
@@ -72,6 +95,7 @@ def get_binomial_beta_posterior_params(
     return alpha_post, beta_post
 
 
+@deprecate_prior_parameter("beta_prior")
 def binomial_beta(n: NUMERIC, x: NUMERIC, prior: Beta) -> Beta:
     """Posterior distribution for a binomial likelihood with a beta prior.
 
@@ -168,6 +192,7 @@ def binomial_beta_predictive(n: NUMERIC, beta: Beta) -> BetaBinomial:
     return BetaBinomial(n=n, alpha=beta.alpha, beta=beta.beta)
 
 
+@deprecate_prior_parameter("beta_prior")
 def bernoulli_beta(x: NUMERIC, prior: Beta) -> Beta:
     """Posterior distribution for a bernoulli likelihood with a beta prior.
 
@@ -217,6 +242,7 @@ def bernoulli_beta_predictive(beta: Beta) -> BetaBinomial:
     return binomial_beta_predictive(n=1, beta=beta)
 
 
+@deprecate_prior_parameter("beta_prior")
 def negative_binomial_beta(r: NUMERIC, n: NUMERIC, x: NUMERIC, prior: Beta) -> Beta:
     """Posterior distribution for a negative binomial likelihood with a beta prior.
 
@@ -254,6 +280,7 @@ def negative_binomial_beta_predictive(r: NUMERIC, beta: Beta) -> BetaNegativeBin
     return BetaNegativeBinomial(n=r, alpha=beta.alpha, beta=beta.beta)
 
 
+@deprecate_prior_parameter("beta_binomial_prior")
 def hypergeometric_beta_binomial(
     x_total: NUMERIC, n: NUMERIC, prior: BetaBinomial
 ) -> BetaBinomial:
@@ -279,6 +306,7 @@ def hypergeometric_beta_binomial(
     return BetaBinomial(n=n, alpha=alpha_post, beta=beta_post)
 
 
+@deprecate_prior_parameter("beta_prior")
 def geometric_beta(x_total, n, prior: Beta, one_start: bool = True) -> Beta:
     """Posterior distribution for a geometric likelihood with a beta prior.
 
@@ -342,6 +370,7 @@ def get_categorical_dirichlet_posterior_params(
     return get_dirichlet_posterior_params(alpha_prior, x)
 
 
+@deprecate_prior_parameter("dirichlet_prior")
 def categorical_dirichlet(x: NUMERIC, prior: Dirichlet) -> Dirichlet:
     """Posterior distribution of Categorical model with Dirichlet prior.
 
@@ -381,6 +410,7 @@ def get_multi_categorical_dirichlet_posterior_params(
     return get_dirichlet_posterior_params(alpha_prior, x)
 
 
+@deprecate_prior_parameter("dirichlet_prior")
 def multinomial_dirichlet(x: NUMERIC, prior: Dirichlet) -> Dirichlet:
     """Posterior distribution of Multinomial model with Dirichlet prior.
 
@@ -454,6 +484,7 @@ def get_poisson_gamma_posterior_params(
     return alpha_post, beta_post
 
 
+@deprecate_prior_parameter("gamma_prior")
 def poisson_gamma(x_total: NUMERIC, n: NUMERIC, prior: Gamma) -> Gamma:
     """Posterior distribution for a poisson likelihood with a gamma prior.
 
@@ -495,6 +526,7 @@ def poisson_gamma_predictive(gamma: Gamma, n: NUMERIC = 1) -> NegativeBinomial:
 get_exponential_gamma_posterior_params = get_poisson_gamma_posterior_params
 
 
+@deprecate_prior_parameter("gamma_prior")
 def exponential_gamma(x_total: NUMERIC, n: NUMERIC, prior: Gamma) -> Gamma:
     """Posterior distribution for an exponential likelihood with a gamma prior.
 
@@ -561,6 +593,7 @@ def exponential_gamma_predictive(gamma: Gamma) -> Lomax:
     return Lomax(alpha=gamma.beta, lam=gamma.alpha)
 
 
+@deprecate_prior_parameter("gamma_prior")
 def gamma_known_shape(
     x_total: NUMERIC, n: NUMERIC, alpha: NUMERIC, prior: Gamma
 ) -> Gamma:
@@ -634,6 +667,7 @@ def gamma_known_shape_predictive(gamma: Gamma, alpha: NUMERIC) -> CompoundGamma:
     return CompoundGamma(alpha=alpha, beta=gamma.alpha, lam=gamma.beta)
 
 
+@deprecate_prior_parameter("normal_prior")
 def normal_known_variance(
     x_total: NUMERIC,
     n: NUMERIC,
@@ -757,6 +791,7 @@ def normal_known_variance_predictive(var: NUMERIC, normal: Normal) -> Normal:
     return Normal(mu=normal.mu, sigma=var_posterior_predictive**0.5)
 
 
+@deprecate_prior_parameter("normal_prior")
 def normal_known_precision(
     x_total: NUMERIC,
     n: NUMERIC,
@@ -819,6 +854,7 @@ def normal_known_precision(
     )
 
 
+@deprecate_prior_parameter("normal_prior")
 def normal_known_precision_predictive(precision: NUMERIC, normal: Normal) -> Normal:
     """Predictive distribution for a normal likelihood with known precision and a normal prior on mean.
 
@@ -881,6 +917,7 @@ def normal_known_precision_predictive(precision: NUMERIC, normal: Normal) -> Nor
     )
 
 
+@deprecate_prior_parameter("inverse_gamma_prior")
 def normal_known_mean(
     x_total: NUMERIC,
     x2_total: NUMERIC,
@@ -970,6 +1007,7 @@ def normal_known_mean_predictive(mu: NUMERIC, inverse_gamma: InverseGamma) -> St
     )
 
 
+@deprecate_prior_parameter("normal_inverse_gamma_prior")
 def normal_normal_inverse_gamma(
     x_total: NUMERIC,
     x2_total: NUMERIC,
@@ -1034,6 +1072,7 @@ def normal_normal_inverse_gamma_predictive(
     )
 
 
+@deprecate_prior_parameter("normal_inverse_gamma_prior")
 def linear_regression(
     X: NUMERIC,
     y: NUMERIC,
@@ -1113,6 +1152,7 @@ def linear_regression_predictive(
     )
 
 
+@deprecate_prior_parameter("pareto_prior")
 def uniform_pareto(
     x_max: NUMERIC, n: NUMERIC, prior: Pareto, max_fn=np.maximum
 ) -> Pareto:
@@ -1156,6 +1196,7 @@ def uniform_pareto(
     return Pareto(x_m=x_m_post, alpha=alpha_post)
 
 
+@deprecate_prior_parameter("gamma_prior")
 def pareto_gamma(
     n: NUMERIC, ln_x_total: NUMERIC, x_m: NUMERIC, prior: Gamma, ln=np.log
 ) -> Gamma:
@@ -1214,6 +1255,7 @@ def pareto_gamma(
     return Gamma(alpha=alpha_post, beta=beta_post)
 
 
+@deprecate_prior_parameter("gamma_proportial_prior")
 def gamma(
     x_total: NUMERIC,
     x_prod: NUMERIC,
@@ -1242,6 +1284,7 @@ def gamma(
     return GammaProportional(p=p_post, q=q_post, r=r_post, s=s_post)
 
 
+@deprecate_prior_parameter("gamma_known_rate_proportial_prior")
 def gamma_known_rate(
     x_prod: NUMERIC,
     n: NUMERIC,
@@ -1268,6 +1311,7 @@ def gamma_known_rate(
     return GammaKnownRateProportional(a=a_post, b=b_post, c=c_post)
 
 
+@deprecate_prior_parameter("beta_proportial_prior")
 def beta(
     x_prod: NUMERIC,
     one_minus_x_prod: NUMERIC,
@@ -1295,6 +1339,7 @@ def beta(
     return BetaProportional(p=p_post, q=q_post, k=k_post)
 
 
+@deprecate_prior_parameter("von_mises_known_concentration_prior")
 def von_mises_known_concentration(
     cos_total: NUMERIC,
     sin_total: NUMERIC,
@@ -1328,6 +1373,7 @@ def von_mises_known_concentration(
     return VonMisesKnownConcentration(a=a_post, b=b_post)
 
 
+@deprecate_prior_parameter("von_mises_known_direction_proportial_prior")
 def von_mises_known_direction(
     centered_cos_total: NUMERIC,
     n: NUMERIC,
@@ -1350,6 +1396,7 @@ def von_mises_known_direction(
     )
 
 
+@deprecate_prior_parameter("inverse_wishart_prior")
 def multivariate_normal_known_mean(
     X: NUMERIC,
     mu: NUMERIC,
@@ -1375,6 +1422,7 @@ def multivariate_normal_known_mean(
     )
 
 
+@deprecate_prior_parameter("normal_inverse_wishart_prior")
 def multivariate_normal(
     X: NUMERIC,
     prior: NormalInverseWishart,
@@ -1457,6 +1505,7 @@ def multivariate_normal(
     )
 
 
+@deprecate_prior_parameter("normal_inverse_wishart_prior")
 def multivariate_normal_predictive(
     normal_inverse_wishart: NormalInverseWishart,
 ) -> MultivariateStudentT:
@@ -1555,6 +1604,7 @@ def multivariate_normal_predictive(
     return MultivariateStudentT(mu=mu, sigma=sigma, nu=nu)
 
 
+@deprecate_prior_parameter("normal_inverse_wishart_prior")
 def log_normal_normal_inverse_gamma(
     ln_x_total: NUMERIC,
     ln_x2_total: NUMERIC,
@@ -1627,6 +1677,7 @@ def log_normal_normal_inverse_gamma(
 
 
 def _use_predictive_instead(func):
+    @wraps(func)
     def wrapper(*args, **kwargs):
         name = func.__name__
         warnings.warn(

--- a/docs/examples/bayesian-update.md
+++ b/docs/examples/bayesian-update.md
@@ -60,7 +60,7 @@ for batch_size in batch_sizes:
         x_total=data.sum(), 
         x2_total=(data ** 2).sum(), 
         n=batch_size, 
-        normal_inverse_gamma_prior=prior
+        prior=prior
     )
 
     beta_samples, variance_samples = posterior.sample_beta(size=1000, return_variance=True, random_state=rng)
@@ -120,7 +120,7 @@ for batch_size in batch_sizes:
     posterior = binomial_beta(
         x=x, 
         n=batch_size, 
-        beta_prior=prior, 
+        prior=prior, 
     )
 
     cumsum += batch_size

--- a/docs/examples/binomial.md
+++ b/docs/examples/binomial.md
@@ -42,7 +42,7 @@ Get the posterior and posterior predictive distributions
 ```python
 # Conjugate prior
 prior = Beta(alpha=1, beta=1)
-posterior: Beta = binomial_beta(n=N, x=X, beta_prior=prior)
+posterior: Beta = binomial_beta(n=N, x=X, prior=prior)
 
 # Comparison
 prior_predictive: BetaBinomial = binomial_beta_predictive(

--- a/docs/examples/bootstrap.md
+++ b/docs/examples/bootstrap.md
@@ -87,7 +87,7 @@ prior for the Poisson distribution.
 def get_posterior_predictive(data: pd.Series, prior: Gamma) -> NegativeBinomial:
     x_total = data.sum()
     n = len(data)
-    posterior = poisson_gamma(x_total=x_total, n=n, gamma_prior=prior)
+    posterior = poisson_gamma(x_total=x_total, n=n, prior=prior)
     return poisson_gamma_predictive(posterior)
 
 def create_conjugate_stat(n_new: int, samples: int, prior: Gamma): 

--- a/docs/examples/generalized-inputs.md
+++ b/docs/examples/generalized-inputs.md
@@ -20,7 +20,7 @@ df = pl.DataFrame({
 
 # Conjugate prior
 prior = Beta(alpha=1, beta=1)
-posterior = binomial_beta(n=df["total"], x=df["successes"], beta_prior=prior)
+posterior = binomial_beta(n=df["total"], x=df["successes"], prior=prior)
 
 ax = posterior.plot_pdf(label=df["total"])
 ax.legend(title="sample size")
@@ -41,7 +41,7 @@ X = Field("successes")
 
 # Conjugate prior
 prior = Beta(alpha=1, beta=1)
-posterior = binomial_beta(n=N, x=X, beta_prior=prior)
+posterior = binomial_beta(n=N, x=X, prior=prior)
 
 print("Posterior alpha:", posterior.alpha)
 print("Posterior beta:", posterior.beta)
@@ -53,7 +53,7 @@ alpha = Field("previous_successes") - 1
 beta = Field("previous_failures") - 1
 
 prior = Beta(alpha=alpha, beta=beta)
-posterior = binomial_beta(n=N, x=X, beta_prior=prior)
+posterior = binomial_beta(n=N, x=X, prior=prior)
 
 print("Posterior alpha:", posterior.alpha)
 print("Posterior beta:", posterior.beta)
@@ -77,7 +77,7 @@ X = 4
 
 # Conjugate prior 
 prior = Beta(alpha=alpha, beta=beta)
-posterior = binomial_beta(n=N, x=X, beta_prior=prior)
+posterior = binomial_beta(n=N, x=X, prior=prior)
 
 # Reconstruct the posterior distribution with PyMC
 prior_dist = pm.Beta.dist(alpha=prior.alpha, beta=prior.beta)

--- a/docs/examples/linear-regression.md
+++ b/docs/examples/linear-regression.md
@@ -49,7 +49,7 @@ X = create_X(x)
 posterior: NormalInverseGamma = linear_regression(
     X=X,
     y=y,
-    normal_inverse_gamma_prior=prior,
+    prior=prior,
 )
 
 ```

--- a/docs/examples/sql.md
+++ b/docs/examples/sql.md
@@ -53,7 +53,7 @@ posterior = normal_normal_inverse_gamma(
     x_total=x_total,
     x2_total=x2_total,
     n=n,
-    normal_inverse_gamma_prior=prior,
+    prior=prior,
 )
 posterior_predictive = normal_normal_inverse_gamma_predictive(posterior)
 ```

--- a/docs/examples/thompson.md
+++ b/docs/examples/thompson.md
@@ -68,7 +68,7 @@ def thompson_step(estimate: Gamma, rng) -> Gamma:
     group_sample = sample_true_distribution(group_to_sample, rng=rng)
     x, n = bayesian_update_stats(group_to_sample, group_sample)
 
-    return exponential_gamma(x, n, gamma_prior=estimate)
+    return exponential_gamma(x, n, prior=estimate)
 ```
 
 After defining a prior / initial estimate for each of the distributions, we can use a for loop in

--- a/docs/examples/unsupported-distributions.md
+++ b/docs/examples/unsupported-distributions.md
@@ -12,7 +12,7 @@ from conjugate.distributions import Beta
 from conjugate.models import geometric_beta
 
 prior = Beta(1, 1)
-posterior: Beta = geometric_beta(x_total=12, n=10, beta_prior=prior)
+posterior: Beta = geometric_beta(x_total=12, n=10, prior=prior)
 ```
 
 We can get posterior predictive samples by: 

--- a/docs/examples/vectorized-inputs.md
+++ b/docs/examples/vectorized-inputs.md
@@ -21,7 +21,7 @@ x = 4
 
 # Analytics 
 prior = Beta(alpha=1, beta=np.array([1, 10]))
-posterior = binomial_beta(n=N, x=x, beta_prior=prior)
+posterior = binomial_beta(n=N, x=x, prior=prior)
 
 # Figure
 colors = ["blue", "red"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,7 @@ N = 10
 prior = Beta(1, 1)
 prior_predictive: BetaBinomial = binomial_beta_predictive(n=N, beta=prior)
 
-posterior: Beta = binomial_beta(n=N, x=X, beta_prior=prior)
+posterior: Beta = binomial_beta(n=N, x=X, prior=prior)
 posterior_predictive: BetaBinomial = binomial_beta_predictive(n=N, beta=posterior) 
 ```
 
@@ -105,7 +105,7 @@ samples = rng.binomial(n=1, p=p, size=n_times)
 # Model
 n = np.arange(n_times) + 1
 prior = Beta(alpha=1, beta=1)
-posterior = binomial_beta(n=n, x=samples.cumsum(), beta_prior=prior)
+posterior = binomial_beta(n=n, x=samples.cumsum(), prior=prior)
 
 # Figure
 plt.plot(n, p, color="black", label="true p", linestyle="--")

--- a/tests/test_example_plots.py
+++ b/tests/test_example_plots.py
@@ -79,7 +79,7 @@ def test_analysis() -> None:
     N = 10
     x = 8
 
-    posterior = binomial_beta(n=N, x=x, beta_prior=prior)
+    posterior = binomial_beta(n=N, x=x, prior=prior)
 
     prior_predictive = binomial_beta_predictive(
         n=5,
@@ -167,7 +167,7 @@ def test_bayesian_update_example() -> None:
             x_total=x.sum(),
             x2_total=(x**2).sum(),
             n=batch_size,
-            normal_inverse_gamma_prior=prior,
+            prior=prior,
         )
         beta_samples, variance_samples = posterior.sample_beta(
             size=1000, return_variance=True, random_state=rng

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -617,3 +617,12 @@ def test_old_model_raises_deprecation_warning() -> None:
         )
 
     assert isinstance(predictive, BetaBinomial)
+
+
+def test_old_parameter_raises_deprecation_warning() -> None:
+    beta = Beta(1, 1)
+    match = "Parameter 'beta_prior' is deprecated, use 'prior' instead."
+    with pytest.warns(DeprecationWarning, match=match):
+        posterior = binomial_beta(n=10, x=5, beta_prior=beta)
+
+    assert isinstance(posterior, Beta)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -168,7 +168,7 @@ def test_get_binomial_beta_posterior_params(
 )
 def test_handle_vectorize_values(alpha, beta, N, x) -> None:
     prior = Beta(alpha=alpha, beta=beta)
-    posterior = binomial_beta(n=N, x=x, beta_prior=prior)
+    posterior = binomial_beta(n=N, x=x, prior=prior)
 
     assert isinstance(posterior, Beta)
 
@@ -182,9 +182,9 @@ def test_geometric_beta_model() -> None:
     N = 10
     X_TOTAL = 12
 
-    posterior_one_start = geometric_beta(x_total=X_TOTAL, n=N, beta_prior=prior)
+    posterior_one_start = geometric_beta(x_total=X_TOTAL, n=N, prior=prior)
     poisterior_zero_start = geometric_beta(
-        x_total=X_TOTAL, n=N, beta_prior=prior, one_start=False
+        x_total=X_TOTAL, n=N, prior=prior, one_start=False
     )
 
     assert isinstance(posterior_one_start, Beta)
@@ -194,7 +194,7 @@ def test_geometric_beta_model() -> None:
 
 def test_poisson_gamma_analysis() -> None:
     prior = Gamma(alpha=1, beta=1)
-    posterior = poisson_gamma(n=10, x_total=5, gamma_prior=prior)
+    posterior = poisson_gamma(n=10, x_total=5, prior=prior)
 
     assert isinstance(posterior, Gamma)
 
@@ -220,7 +220,7 @@ def test_poisson_gamma_analysis() -> None:
 )
 def test_multinomial_dirichlet_analysis(alpha) -> None:
     prior = Dirichlet(alpha=alpha)
-    posterior = multinomial_dirichlet(x=1, dirichlet_prior=prior)
+    posterior = multinomial_dirichlet(x=1, prior=prior)
 
     assert isinstance(posterior, Dirichlet)
     assert isinstance(posterior.alpha, np.ndarray)
@@ -287,7 +287,7 @@ def test_uniform_pareto_python_objects() -> None:
     n_samples = len(samples)
 
     prior = Pareto(x_m=1, alpha=1)
-    posterior = uniform_pareto(x_max=max(samples), n=n_samples, pareto_prior=prior)
+    posterior = uniform_pareto(x_max=max(samples), n=n_samples, prior=prior)
 
     assert isinstance(posterior, Pareto)
     assert posterior.x_m == 5
@@ -299,7 +299,7 @@ def test_uniform_pareto_numpy_objects() -> None:
     n_samples = len(samples)
 
     prior = Pareto(x_m=1, alpha=1)
-    posterior = uniform_pareto(x_max=samples.max(), n=n_samples, pareto_prior=prior)
+    posterior = uniform_pareto(x_max=samples.max(), n=n_samples, prior=prior)
 
     assert isinstance(posterior, Pareto)
     assert posterior.x_m == 5
@@ -316,7 +316,7 @@ def test_pareto_gamma() -> None:
         n=n_samples,
         ln_x_total=np.log(samples).sum(),
         x_m=samples.min(),
-        gamma_prior=prior,
+        prior=prior,
     )
 
     assert isinstance(posterior, Gamma)
@@ -331,7 +331,7 @@ def test_exponential_gamma() -> None:
     x_total = sum(data)
 
     prior = Gamma(alpha=1, beta=1)
-    posterior = exponential_gamma(x_total=x_total, n=n, gamma_prior=prior)
+    posterior = exponential_gamma(x_total=x_total, n=n, prior=prior)
 
     assert isinstance(posterior, Gamma)
 
@@ -347,7 +347,7 @@ def test_normal_known_variance() -> None:
 
     prior = Normal(0, 1)
     posterior = normal_known_variance(
-        x_total=data.sum(), n=len(data), var=known_var, normal_prior=prior
+        x_total=data.sum(), n=len(data), var=known_var, prior=prior
     )
 
     assert isinstance(posterior, Normal)
@@ -369,7 +369,7 @@ def test_normal_known_mean() -> None:
         x2_total=(data**2).sum(),
         n=len(data),
         mu=known_mu,
-        inverse_gamma_prior=prior,
+        prior=prior,
     )
 
     assert isinstance(posterior, InverseGamma)
@@ -393,7 +393,7 @@ def test_normal_normal_inverse_gamma() -> None:
         x_total=data.sum(),
         x2_total=(data**2).sum(),
         n=n,
-        normal_inverse_gamma_prior=prior,
+        prior=prior,
     )
 
     assert isinstance(posterior, NormalInverseGamma)
@@ -429,7 +429,7 @@ def test_gamma_known_shape(shape) -> None:
         x_total=data.sum(),
         n=len(data),
         alpha=shape,
-        gamma_prior=prior,
+        prior=prior,
     )
 
     assert isinstance(posterior, Gamma)
@@ -450,7 +450,7 @@ def test_gamma_proportional_model() -> None:
         x_total=samples.sum(),
         x_prod=np.prod(samples),
         n=n_samples,
-        proportional_prior=prior,
+        prior=prior,
     )
 
     assert isinstance(posterior, GammaProportional)
@@ -470,7 +470,7 @@ def test_gamma_known_rate() -> None:
         x_prod=np.prod(samples),
         n=n_samples,
         beta=true_beta,
-        proportional_prior=prior,
+        prior=prior,
     )
 
     assert isinstance(posterior, GammaKnownRateProportional)
@@ -488,7 +488,7 @@ def test_beta_proportional_model() -> None:
         x_prod=np.prod(samples),
         one_minus_x_prod=np.prod(1 - samples),
         n=n_samples,
-        proportional_prior=prior,
+        prior=prior,
     )
 
     assert isinstance(posterior, BetaProportional)
@@ -517,7 +517,7 @@ def test_multivariate_normal() -> None:
     )
     posterior = multivariate_normal(
         X=X,
-        normal_inverse_wishart_prior=prior,
+        prior=prior,
     )
     assert isinstance(posterior, NormalInverseWishart)
 
@@ -545,7 +545,7 @@ def test_log_normal_normal_inverse_gamma() -> None:
         ln_x_total=ln_data.sum(),
         ln_x2_total=(ln_data**2).sum(),
         n=n,
-        normal_inverse_gamma_prior=prior,
+        prior=prior,
     )
 
     assert isinstance(posterior, NormalInverseGamma)
@@ -558,7 +558,7 @@ def test_bernoulli_beta() -> None:
     prior = Beta(alpha=1, beta=1)
     posterior = bernoulli_beta(
         x=0,
-        beta_prior=prior,
+        prior=prior,
     )
     assert posterior == Beta(alpha=1, beta=2)
 
@@ -576,7 +576,7 @@ def test_negative_binomial_beta() -> None:
         r=10,
         n=15,
         x=5,
-        beta_prior=prior,
+        prior=prior,
     )
 
     assert posterior == Beta(
@@ -597,7 +597,7 @@ def test_hypergeometric_beta_binomial() -> None:
     posterior = hypergeometric_beta_binomial(
         x_total=5,
         n=20,
-        beta_binomial_prior=prior,
+        prior=prior,
     )
 
     assert posterior == BetaBinomial(


### PR DESCRIPTION
Closes #93

TODO: 

- [x] Migrate all of the documentation
- [x] Create a decorator that will throw deprecation warning if the previous behavior is used
