### PR TITLE
Migrate to common predictive parameter

### DIFF
--- a/conjugate/models.py
+++ b/conjugate/models.py
@@ -441,7 +441,8 @@ def categorical_dirichlet(x: NUMERIC, prior: Dirichlet) -> Dirichlet:
 @deprecate_distribution_parameter("dirichlet")
 @validate_distribution_type
 def categorical_dirichlet_predictive(
-    distribution: Dirichlet, n: NUMERIC = 1
+    distribution: Dirichlet,
+    n: NUMERIC = 1,
 ) -> DirichletMultinomial:
     """Predictive distribution of Categorical model with Dirichlet distribution.
 
@@ -839,11 +840,11 @@ def normal_known_variance_predictive(var: NUMERIC, distribution: Normal) -> Norm
 
         prior_predictive = normal_known_variance_predictive(
             var=known_var,
-            distribution=prior
+            distribution=prior,
         )
         posterior_predictive = normal_known_variance_predictive(
             var=known_var,
-            distribution=posterior
+            distribution=posterior,
         )
 
         bound = 5
@@ -924,14 +925,17 @@ def normal_known_precision(
     )
 
 
-@deprecate_prior_parameter("normal_prior")
-@validate_prior_type
-def normal_known_precision_predictive(precision: NUMERIC, normal: Normal) -> Normal:
+@deprecate_distribution_parameter("normal")
+@validate_distribution_type
+def normal_known_precision_predictive(
+    precision: NUMERIC,
+    distribution: Normal,
+) -> Normal:
     """Predictive distribution for a normal likelihood with known precision and a normal prior on mean.
 
     Args:
         precision: known precision
-        normal: Normal posterior distribution for the mean
+        distribution: Normal posterior distribution for the mean
 
     Returns:
         Normal predictive distribution
@@ -965,11 +969,11 @@ def normal_known_precision_predictive(precision: NUMERIC, normal: Normal) -> Nor
 
         prior_predictive = normal_known_precision_predictive(
             precision=known_precision,
-            normal=prior
+            distribution=prior,
         )
         posterior_predictive = normal_known_precision_predictive(
             precision=known_precision,
-            normal=posterior
+            distribution=posterior,
         )
 
         bound = 5
@@ -984,7 +988,7 @@ def normal_known_precision_predictive(precision: NUMERIC, normal: Normal) -> Nor
     """
     return normal_known_variance_predictive(
         var=1 / precision,
-        normal=normal,
+        distribution=distribution,
     )
 
 
@@ -1060,13 +1064,13 @@ def normal_known_mean_predictive(mu: NUMERIC, distribution: InverseGamma) -> Stu
         ax = plt.subplot(111)
         prior_predictive = normal_known_mean_predictive(
             mu=known_mu,
-            distribution=prior
+            distribution=prior,
         )
         prior_predictive.set_bounds(-bound, bound).plot_pdf(ax=ax, label="prior predictive")
         true.set_bounds(-bound, bound).plot_pdf(ax=ax, label="true distribution")
         posterior_predictive = normal_known_mean_predictive(
             mu=known_mu,
-            distribution=posterior
+            distribution=posterior,
         )
         posterior_predictive.set_bounds(-bound, bound).plot_pdf(ax=ax, label="posterior predictive")
         ax.legend()
@@ -1206,7 +1210,9 @@ def linear_regression(
 @deprecate_distribution_parameter("normal_inverse_gamma")
 @validate_distribution_type
 def linear_regression_predictive(
-    distribution: NormalInverseGamma, X: NUMERIC, eye=np.eye
+    distribution: NormalInverseGamma,
+    X: NUMERIC,
+    eye=np.eye,
 ) -> MultivariateStudentT:
     """Predictive distribution for a linear regression model with a normal inverse gamma prior.
 

--- a/docs/examples/binomial.md
+++ b/docs/examples/binomial.md
@@ -47,11 +47,11 @@ posterior: Beta = binomial_beta(n=N, x=X, prior=prior)
 # Comparison
 prior_predictive: BetaBinomial = binomial_beta_predictive(
     n=N, 
-    beta=prior, 
+    distribution=prior, 
 )
 posterior_predictive: BetaBinomial = binomial_beta_predictive(
     n=N, 
-    beta=posterior, 
+    distribution=posterior, 
 )
 ```
 

--- a/docs/examples/bootstrap.md
+++ b/docs/examples/bootstrap.md
@@ -88,7 +88,7 @@ def get_posterior_predictive(data: pd.Series, prior: Gamma) -> NegativeBinomial:
     x_total = data.sum()
     n = len(data)
     posterior = poisson_gamma(x_total=x_total, n=n, prior=prior)
-    return poisson_gamma_predictive(posterior)
+    return poisson_gamma_predictive(distribution=posterior)
 
 def create_conjugate_stat(n_new: int, samples: int, prior: Gamma): 
     def conjugate_stat(data: pd.Series) -> pd.Series: 

--- a/docs/examples/linear-regression.md
+++ b/docs/examples/linear-regression.md
@@ -64,7 +64,7 @@ The multivariate student-t distribution is used for the posterior predictive dis
 x_lim_new = 1.5 * x_lim
 x_new = np.linspace(-x_lim_new, x_lim_new, 20)
 X_new = create_X(x_new)
-pp: MultivariateStudentT = linear_regression_predictive(normal_inverse_gamma=posterior, X=X_new)
+pp: MultivariateStudentT = linear_regression_predictive(distribution=posterior, X=X_new)
 
 samples = pp.dist.rvs(5_000).T
 df_samples = pd.DataFrame(samples, index=x_new)

--- a/docs/examples/sql.md
+++ b/docs/examples/sql.md
@@ -55,7 +55,7 @@ posterior = normal_normal_inverse_gamma(
     n=n,
     prior=prior,
 )
-posterior_predictive = normal_normal_inverse_gamma_predictive(posterior)
+posterior_predictive = normal_normal_inverse_gamma_predictive(distribution=posterior)
 ```
 
 Then add the columns we want from the inference

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,10 +55,10 @@ N = 10
 
 # Analytics
 prior = Beta(1, 1)
-prior_predictive: BetaBinomial = binomial_beta_predictive(n=N, beta=prior)
+prior_predictive: BetaBinomial = binomial_beta_predictive(n=N, distribution=prior)
 
 posterior: Beta = binomial_beta(n=N, x=X, prior=prior)
-posterior_predictive: BetaBinomial = binomial_beta_predictive(n=N, beta=posterior) 
+posterior_predictive: BetaBinomial = binomial_beta_predictive(n=N, distribution=posterior) 
 ```
 
 From here, do any analysis you'd like!

--- a/tests/test_example_plots.py
+++ b/tests/test_example_plots.py
@@ -83,11 +83,11 @@ def test_analysis() -> None:
 
     prior_predictive = binomial_beta_predictive(
         n=5,
-        beta=prior,
+        distribution=prior,
     )
     posterior_predictive = binomial_beta_predictive(
         n=5,
-        beta=posterior,
+        distribution=posterior,
     )
 
     fig, axes = plt.subplots(1, 2, figsize=(15, 7))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -198,10 +198,10 @@ def test_poisson_gamma_analysis() -> None:
 
     assert isinstance(posterior, Gamma)
 
-    pp = poisson_gamma_predictive(gamma=posterior)
+    pp = poisson_gamma_predictive(distribution=posterior)
     assert isinstance(pp, NegativeBinomial)
 
-    pp_7days = poisson_gamma_predictive(gamma=posterior, n=7)
+    pp_7days = poisson_gamma_predictive(distribution=posterior, n=7)
     assert isinstance(pp_7days, NegativeBinomial)
 
 
@@ -276,9 +276,7 @@ def test_linear_regression(intercept, slope, sigma) -> None:
     assert between(slope, *np.quantile(beta_samples[:, 1], q=q))
     assert between(sigma, *np.quantile(sigma_samples, q=q))
 
-    posterior_predictive = linear_regression_predictive(
-        normal_inverse_gamma=posterior, X=X
-    )
+    posterior_predictive = linear_regression_predictive(distribution=posterior, X=X)
     assert isinstance(posterior_predictive, MultivariateStudentT)
 
 
@@ -335,7 +333,7 @@ def test_exponential_gamma() -> None:
 
     assert isinstance(posterior, Gamma)
 
-    posterior_predictive = exponential_gamma_predictive(gamma=posterior)
+    posterior_predictive = exponential_gamma_predictive(distribution=posterior)
 
     assert isinstance(posterior_predictive, Lomax)
 
@@ -353,7 +351,7 @@ def test_normal_known_variance() -> None:
     assert isinstance(posterior, Normal)
 
     posterior_predictive = normal_known_variance_predictive(
-        var=known_var, normal=posterior
+        var=known_var, distribution=posterior
     )
     assert isinstance(posterior_predictive, Normal)
 
@@ -375,7 +373,8 @@ def test_normal_known_mean() -> None:
     assert isinstance(posterior, InverseGamma)
 
     posterior_predictive = normal_known_mean_predictive(
-        mu=known_mu, inverse_gamma=posterior
+        mu=known_mu,
+        distribution=posterior,
     )
     assert isinstance(posterior_predictive, StudentT)
 
@@ -399,12 +398,12 @@ def test_normal_normal_inverse_gamma() -> None:
     assert isinstance(posterior, NormalInverseGamma)
 
     posterior_predictive = normal_normal_inverse_gamma_predictive(
-        normal_inverse_gamma=posterior,
+        distribution=posterior,
     )
     assert isinstance(posterior_predictive, StudentT)
 
     prior_predictive = normal_normal_inverse_gamma_predictive(
-        normal_inverse_gamma=prior,
+        distribution=prior,
     )
 
     assert (
@@ -434,7 +433,10 @@ def test_gamma_known_shape(shape) -> None:
 
     assert isinstance(posterior, Gamma)
 
-    posterior_predictive = gamma_known_shape_predictive(alpha=shape, gamma=posterior)
+    posterior_predictive = gamma_known_shape_predictive(
+        alpha=shape,
+        distribution=posterior,
+    )
     assert isinstance(posterior_predictive, CompoundGamma)
 
 
@@ -521,8 +523,8 @@ def test_multivariate_normal() -> None:
     )
     assert isinstance(posterior, NormalInverseWishart)
 
-    prior_predictive = multivariate_normal_predictive(normal_inverse_wishart=prior)
-    posterior_predictive = multivariate_normal_predictive(posterior)
+    prior_predictive = multivariate_normal_predictive(distribution=prior)
+    posterior_predictive = multivariate_normal_predictive(distribution=posterior)
     assert isinstance(posterior_predictive, MultivariateStudentT)
     assert prior_predictive.dist.logpdf(mu) < posterior_predictive.dist.logpdf(mu)
     assert (
@@ -565,7 +567,7 @@ def test_bernoulli_beta() -> None:
 
 def test_bernoulli_beta_predictive() -> None:
     prior = Beta(alpha=1, beta=1)
-    pp = bernoulli_beta_predictive(beta=prior)
+    pp = bernoulli_beta_predictive(distribution=prior)
 
     assert pp == BetaBinomial(n=1, alpha=1, beta=1)
 
@@ -587,7 +589,7 @@ def test_negative_binomial_beta() -> None:
 
 def test_negative_binomial_beta_predictive() -> None:
     prior = Beta(alpha=1, beta=1)
-    pp = negative_binomial_beta_predictive(r=10, beta=prior)
+    pp = negative_binomial_beta_predictive(r=10, distribution=prior)
 
     assert pp == BetaNegativeBinomial(n=10, alpha=1, beta=1)
 
@@ -613,7 +615,7 @@ def test_old_model_raises_deprecation_warning() -> None:
     with pytest.warns(DeprecationWarning, match=match):
         predictive = binomial_beta_posterior_predictive(
             n=10,
-            beta=beta,
+            distribution=beta,
         )
 
     assert isinstance(predictive, BetaBinomial)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -621,7 +621,7 @@ def test_old_model_raises_deprecation_warning() -> None:
     assert isinstance(predictive, BetaBinomial)
 
 
-def test_old_parameter_raises_deprecation_warning() -> None:
+def test_old_parameter_raises_deprecation_warning_model() -> None:
     beta = Beta(1, 1)
     match = "Parameter 'beta_prior' is deprecated, use 'prior' instead."
     with pytest.warns(DeprecationWarning, match=match):
@@ -638,3 +638,22 @@ def test_wrong_prior_type_raises(prior_name: str) -> None:
     match = "Expected prior to be of type 'Beta', got 'Gamma' instead."
     with pytest.raises(ValueError, match=match):
         bernoulli_beta(x=0, **kwargs)
+
+
+def test_old_parameter_raises_deprecation_warning_predictive() -> None:
+    distribution = Beta(1, 1)
+    match = "Parameter 'beta' is deprecated, use 'distribution' instead."
+    with pytest.warns(DeprecationWarning, match=match):
+        predictive = bernoulli_beta_predictive(beta=distribution)
+
+    assert isinstance(predictive, BetaBinomial)
+
+
+@pytest.mark.filterwarnings("ignore")
+@pytest.mark.parametrize("distribution_name", ["distribution", "beta"])
+def test_wrong_distribution_type_raises(distribution_name: str) -> None:
+    distribution = Gamma(1, 1)
+    kwargs = {distribution_name: distribution}
+    match = "Expected distribution to be of type 'Beta', got 'Gamma' instead."
+    with pytest.raises(ValueError, match=match):
+        bernoulli_beta_predictive(**kwargs)


### PR DESCRIPTION
Closes #97

Migrate to a common parameter named `distribution` for all the predictive functions
